### PR TITLE
Refactor inputs api

### DIFF
--- a/src/Html/A11y.elm
+++ b/src/Html/A11y.elm
@@ -1,12 +1,14 @@
 module Html.A11y
     exposing
-        ( Input
-        , textInput
-        , radioInput
-        , checkboxInput
-        , leftLabeledInput
-        , rightLabeledInput
-        , invisibleLabeledInput
+        ( textLeftLabeled
+        , textRightLabeled
+        , textInvisibleLabel
+        , radioLeftLabeled
+        , radioRightLabeled
+        , radioInvisibleLabel
+        , checkBoxLeftLabeled
+        , checkBoxRightLabeled
+        , checkBoxInvisibleLabel
         , tabList
         , tab
         , tabPanel
@@ -17,9 +19,21 @@ module Html.A11y
 
 {-|
 ## Inputs
-@docs Input
-@docs textInput, radioInput, checkboxInput
-@docs leftLabeledInput, rightLabeledInput, invisibleLabeledInput
+
+Inputs defined in this library are offered in three varieties: left-labeled, right-labeled, and featuring an invisible-label.
+Invisible-labelled views require an id.
+
+### Text Inputs
+
+@docs textLeftLabeled, textRightLabeled, textInvisibleLabel
+
+### Radio Inputs
+
+@docs radioLeftLabeled, radioRightLabeled, radioInvisibleLabel
+
+### CheckBox Inputs
+
+@docs checkBoxLeftLabeled, checkBoxRightLabeled, checkBoxInvisibleLabel
 
 ## Tabs
 @docs tabList, tab, tabPanel
@@ -34,71 +48,124 @@ import Tags.Inputs as Inputs
 import Tags.Tabs as Tabs
 
 
-{-| Describes the model used in input views in this library.
+{- *** Text Inputs *** -}
+
+
+textModel : String -> List (Html.Attribute msg) -> Html msg -> Inputs.Input msg
+textModel value attributes label =
+    { typeAndValue = Inputs.textInput value
+    , label = label
+    , attributes = attributes
+    }
+
+
+{-| Construct a left-labeled text input.
+
+    textLeftLabeled "This appears in the text input." [] <| text "I'm the label!"
 -}
-type alias Input msg =
-    Inputs.Input msg
+textLeftLabeled : String -> List (Html.Attribute msg) -> Html msg -> Html msg
+textLeftLabeled value attributes label =
+    Inputs.leftLabeledInput (textModel value attributes label)
 
 
-{-| Use helpers like `textInput` and `radioInput` to create InputTypeAndValue items.
+{-| Construct a right-labeled text input.
+
+    textRightLabeled "This appears in the text input." [] <| text "I'm the label!"
 -}
-type alias InputTypeAndValue =
-    Inputs.InputTypeAndValue
+textRightLabeled : String -> List (Html.Attribute msg) -> Html msg -> Html msg
+textRightLabeled value attributes label =
+    Inputs.rightLabeledInput (textModel value attributes label)
 
 
-{-| This will construct a text input with the value passed in.
+{-| Construct a text input with an invisible label.
 
-    textInput "This appears in the text input."
+    textInvisibleLabel "best-input-everrr" "This appears in the text input." [] <| text "I'm the label!"
 -}
-textInput : String -> InputTypeAndValue
-textInput =
-    Inputs.textInput
+textInvisibleLabel : String -> String -> List (Html.Attribute msg) -> Html msg -> Html msg
+textInvisibleLabel id value attributes label =
+    Inputs.invisibleLabeledInput (textModel value attributes label) id
 
 
-{-| This will construct a radio input. The first argument is the radio group name
-in common across radio items. THe second argument is the value of the radio.
-The third is whether the radio is checked or not.
 
-    radioInput "radio_name" "This is the actual value of the radio." True
+{- *** Radio Inputs *** -}
+
+
+radioModel : String -> String -> Bool -> List (Html.Attribute msg) -> Html msg -> Inputs.Input msg
+radioModel groupName value checked attributes label =
+    { typeAndValue = Inputs.radioInput groupName value checked
+    , label = label
+    , attributes = attributes
+    }
+
+
+{-| Construct a left-labeled radio input.
+
+    radioLeftLabeled "radio_name" "This is the actual value of the radio." True [] <| text "I'm the label!"
 -}
-radioInput : String -> String -> Bool -> InputTypeAndValue
-radioInput =
-    Inputs.radioInput
+radioLeftLabeled : String -> String -> Bool -> List (Html.Attribute msg) -> Html msg -> Html msg
+radioLeftLabeled groupName value checked attributes label =
+    Inputs.leftLabeledInput (radioModel groupName value checked attributes label)
 
 
-{-| This will construct a checkbox input. THe first argument is the value of the checkbox.
-The second is whether the radio is checked, unchecked, or indeterminate.
+{-| Construct a right-labeled radio input.
 
-    checkboxInput "radio_name" "This is the actual value of the radio." True
+    radioRightLabeled  "radio_name" "This is the actual value of the radio." True [] <| text "I'm the label!"
 -}
-checkboxInput : String -> Maybe Bool -> InputTypeAndValue
-checkboxInput =
-    Inputs.checkboxInput
+radioRightLabeled : String -> String -> Bool -> List (Html.Attribute msg) -> Html msg -> Html msg
+radioRightLabeled groupName value checked attributes label =
+    Inputs.rightLabeledInput (radioModel groupName value checked attributes label)
 
 
-{-| Produces a labeled input of a given label type. The label appears on the left side on the input.
+{-| Construct a radio button with an invisible label.
+
+    radioInvisibleLabel "best-input-everrr" "This is the actual value of the radio." [] <| text "I'm the label!"
 -}
-leftLabeledInput : Input msg -> Html msg
-leftLabeledInput =
-    Inputs.leftLabeledInput
+radioInvisibleLabel : String -> String -> String -> Bool -> List (Html.Attribute msg) -> Html msg -> Html msg
+radioInvisibleLabel id groupName value checked attributes label =
+    Inputs.invisibleLabeledInput (radioModel groupName value checked attributes label) id
 
 
-{-| Produces a labeled input of a given label type. The label appears on the right side on the input.
+
+{- *** Checkbox Inputs *** -}
+
+
+checkBoxModel : String -> Maybe Bool -> List (Html.Attribute msg) -> Html msg -> Inputs.Input msg
+checkBoxModel value checked attributes label =
+    { typeAndValue = Inputs.checkboxInput value checked
+    , label = label
+    , attributes = attributes
+    }
+
+
+{-| Construct a left-labeled check box input.
+
+    checkBoxLeftLabeled "This is the actual value of the check box." (Just True) [] <| text "I'm the label!"
 -}
-rightLabeledInput : Input msg -> Html msg
-rightLabeledInput =
-    Inputs.rightLabeledInput
+checkBoxLeftLabeled : String -> Maybe Bool -> List (Html.Attribute msg) -> Html msg -> Html msg
+checkBoxLeftLabeled value checked attributes label =
+    Inputs.leftLabeledInput (checkBoxModel value checked attributes label)
 
 
-{-| Produces a labeled input of a given label type.
-This label is visibly hidden, but is still available for screen readers.
-E.g., use this input if your design asks that you convey information via placeholders
-rather than visible labels.
-Requires that you pass an id.
+{-| Construct a right-labeled check box input.
+
+    checkBoxRightLabeled  "This is the actual value of the checkBox." (Just True) [] <| text "I'm the label!"
 -}
-invisibleLabeledInput : Input msg -> String -> Html msg
-invisibleLabeledInput =
-    Inputs.invisibleLabeledInput
+checkBoxRightLabeled : String -> Maybe Bool -> List (Html.Attribute msg) -> Html msg -> Html msg
+checkBoxRightLabeled value checked attributes label =
+    Inputs.rightLabeledInput (checkBoxModel value checked attributes label)
+
+
+{-| Construct a check box with an invisible label.
+
+    checkBoxInvisibleLabel "checkbox-id" "Checkbox value" (Just False) [] <| text "I'm the label!"
+-}
+checkBoxInvisibleLabel : String -> String -> Maybe Bool -> List (Html.Attribute msg) -> Html msg -> Html msg
+checkBoxInvisibleLabel id value checked attributes label =
+    Inputs.invisibleLabeledInput (checkBoxModel value checked attributes label) id
+
+
+
+{- *** Tabs *** -}
 
 
 {-| Create a tablist. This is the outer container for a list of tabs.
@@ -122,6 +189,10 @@ tab =
 tabPanel : List (Html.Attribute msg) -> List (Html msg) -> Html msg
 tabPanel =
     Tabs.tabPanel
+
+
+
+{- *** Images *** -}
 
 
 {-| Use this tag when the image provides information not expressed in the text of the page.

--- a/tests/Html/A11ySpec.elm
+++ b/tests/Html/A11ySpec.elm
@@ -10,98 +10,105 @@ import Test exposing (..)
 spec : Test
 spec =
     describe "Html.Attributes.A11ySpec"
-        [ describe "inputs" <|
-            [ describe "leftLabeledInput" (inputTests leftLabeledInput)
-            , describe "rightLabeledInput" (inputTests rightLabeledInput)
-            , describe "invisibleLabeledInput" (inputTests ((flip invisibleLabeledInput) "input-id"))
-            ]
+        [ inputsTests
         , describe "tabs" []
         , imagesTests
         ]
 
 
-inputTests : (Input msg -> Html msg) -> List Test
-inputTests toView =
+inputsTests : Test
+inputsTests =
+    describe "inputs" <|
+        [ describe "text inputs" <|
+            let
+                expected =
+                    { label = "the label"
+                    , value = "the value"
+                    , type_ = "text"
+                    }
+            in
+                [ describe "textLeftLabeled"
+                    [ baseInputTests expected <|
+                        textLeftLabeled "the value" [] (text "the label")
+                    ]
+                , describe "textRightLabeled"
+                    [ baseInputTests expected <|
+                        textRightLabeled "the value" [] (text "the label")
+                    ]
+                , describe "textInvisibleLabel"
+                    [ baseInputTests expected <|
+                        textInvisibleLabel "id" "the value" [] (text "the label")
+                    ]
+                ]
+        , describe "radio inputs" <|
+            let
+                expected =
+                    { label = "the label"
+                    , value = "the value"
+                    , type_ = "radio"
+                    }
+            in
+                [ describe "radioLeftLabeled"
+                    [ baseInputTests expected <|
+                        radioLeftLabeled "group_name" "the value" True [] (text "the label")
+                    ]
+                , describe "radioRightLabeled"
+                    [ baseInputTests expected <|
+                        radioRightLabeled "group_name" "the value" True [] (text "the label")
+                    ]
+                , describe "radioInvisibleLabel"
+                    [ baseInputTests expected <|
+                        radioInvisibleLabel "group_name" "id" "the value" True [] (text "the label")
+                    ]
+                ]
+        , describe "checkbox inputs" <|
+            let
+                expected =
+                    { label = "the label"
+                    , value = "the value"
+                    , type_ = "checkbox"
+                    }
+            in
+                [ describe "checkBoxLeftLabeled"
+                    [ baseInputTests expected <|
+                        checkBoxLeftLabeled "the value" (Just True) [] (text "the label")
+                    ]
+                , describe "checkBoxRightLabeled"
+                    [ baseInputTests expected <|
+                        checkBoxRightLabeled "the value" (Just True) [] (text "the label")
+                    ]
+                , describe "checkBoxInvisibleLabel"
+                    [ baseInputTests expected <|
+                        checkBoxInvisibleLabel "id" "the value" (Just True) [] (text "the label")
+                    ]
+                ]
+        ]
+
+
+baseInputTests : { label : String, value : String, type_ : String } -> Html msg -> Test
+baseInputTests { label, value, type_ } view =
     let
-        queryView model =
-            div [] [ toView model ]
+        queryView =
+            div [] [ Html.A11y.figure [] [ view ] ]
                 |> Query.fromHtml
     in
-        [ describe "textInput" <|
-            let
-                mockInputModel =
-                    { label = text "Name"
-                    , typeAndValue = textInput "Tessa"
-                    , attributes = []
-                    }
-            in
-                [ baseInputTests (queryView mockInputModel)
-                    { label = "Name", value = "Tessa", type_ = "text" }
-                ]
-        , describe "radioInput" <|
-            let
-                mockInputModel =
-                    { label = text "Radio input"
-                    , typeAndValue = radioInput "radio-group-name" "8" True
-                    , attributes = []
-                    }
-            in
-                [ baseInputTests (queryView mockInputModel)
-                    { label = "Radio input", value = "8", type_ = "radio" }
-                , test "is checked" <|
-                    \() ->
-                        queryView mockInputModel
-                            |> Query.find [ Selector.tag "input" ]
-                            |> Query.has [ Selector.boolAttribute "checked" True ]
-                ]
-        , describe "checkboxInput" <|
-            let
-                mockInputModel maybeSelected =
-                    { label = text "To check or not to check?"
-                    , typeAndValue = checkboxInput "some sick value" maybeSelected
-                    , attributes = []
-                    }
-            in
-                [ baseInputTests (queryView <| mockInputModel (Just True))
-                    { label = "To check or not to check?", value = "some sick value", type_ = "checkbox" }
-                , test "is checked" <|
-                    \() ->
-                        queryView (mockInputModel (Just True))
-                            |> Query.find [ Selector.tag "input" ]
-                            |> Query.has [ Selector.boolAttribute "checked" True ]
-                , test "is not checked" <|
-                    \() ->
-                        queryView (mockInputModel (Just False))
-                            |> Query.find [ Selector.tag "input" ]
-                            |> Query.has [ Selector.boolAttribute "checked" False ]
-                , test "is indeterminate" <|
-                    \() ->
-                        queryView (mockInputModel Nothing)
-                            |> Query.find [ Selector.tag "input" ]
-                            |> Query.has [ Selector.boolAttribute "indeterminate" True ]
-                ]
-        ]
-
-
-baseInputTests : Query.Single -> { label : String, value : String, type_ : String } -> Test
-baseInputTests queryView { label, value, type_ } =
-    describe "Basic input tests"
-        [ test "has label with the given label text" <|
-            \() ->
-                queryView
-                    |> Query.find [ Selector.tag "label" ]
-                    |> Query.has [ Selector.text label ]
-        , test "has input with the appropriate value" <|
-            \() ->
-                queryView
-                    |> Query.find [ Selector.tag "input" ]
-                    |> Query.has [ Selector.attribute "value" value ]
-        , test "is an input of the appropriate type" <|
-            \() ->
-                queryView
-                    |> Query.find [ Selector.tag "input" ]
-                    |> Query.has [ Selector.attribute "type" type_ ]
-        ]
+        describe "Basic input tests"
+            [ test "has label with the given label text" <|
+                \() ->
+                    queryView
+                        |> Query.find [ Selector.tag "label" ]
+                        |> Query.has [ Selector.text label ]
+            , test "has input with the appropriate value" <|
+                \() ->
+                    queryView
+                        |> Query.find [ Selector.tag "input" ]
+                        |> Query.has [ Selector.attribute "value" value ]
+            , test "is an input of the appropriate type" <|
+                \() ->
+                    queryView
+                        |> Query.find [ Selector.tag "input" ]
+                        |> Query.has [ Selector.attribute "type" type_ ]
+            ]
 
 
 imagesTests : Test

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -2,9 +2,10 @@ port module Main exposing (..)
 
 import Html.A11ySpec
 import Html.Attributes.A11ySpec
+import Json.Encode exposing (Value)
+import Tags.InputsSpec
 import Test
 import Test.Runner.Node exposing (run, TestProgram)
-import Json.Encode exposing (Value)
 
 
 main : TestProgram
@@ -13,6 +14,7 @@ main =
         Test.concat
             [ Html.A11ySpec.spec
             , Html.Attributes.A11ySpec.spec
+            , Tags.InputsSpec.spec
             ]
 
 

--- a/tests/Tags/InputsSpec.elm
+++ b/tests/Tags/InputsSpec.elm
@@ -1,0 +1,100 @@
+module Tags.InputsSpec exposing (spec)
+
+import Html exposing (..)
+import Tags.Inputs exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Tags.InputsSpec"
+        [ describe "leftLabeledInput" (inputTests leftLabeledInput)
+        , describe "rightLabeledInput" (inputTests rightLabeledInput)
+        , describe "invisibleLabeledInput" (inputTests ((flip invisibleLabeledInput) "input-id"))
+        ]
+
+
+inputTests : (Input msg -> Html msg) -> List Test
+inputTests toView =
+    let
+        queryView model =
+            div [] [ toView model ]
+                |> Query.fromHtml
+    in
+        [ describe "textInput" <|
+            let
+                mockInputModel =
+                    { label = text "Name"
+                    , typeAndValue = textInput "Tessa"
+                    , attributes = []
+                    }
+            in
+                [ baseInputTests (queryView mockInputModel)
+                    { label = "Name", value = "Tessa", type_ = "text" }
+                ]
+        , describe "radioInput" <|
+            let
+                mockInputModel =
+                    { label = text "Radio input"
+                    , typeAndValue = radioInput "radio-group-name" "8" True
+                    , attributes = []
+                    }
+            in
+                [ baseInputTests (queryView mockInputModel)
+                    { label = "Radio input", value = "8", type_ = "radio" }
+                , test "is checked" <|
+                    \() ->
+                        queryView mockInputModel
+                            |> Query.find [ Selector.tag "input" ]
+                            |> Query.has [ Selector.boolAttribute "checked" True ]
+                ]
+        , describe "checkboxInput" <|
+            let
+                mockInputModel maybeSelected =
+                    { label = text "To check or not to check?"
+                    , typeAndValue = checkboxInput "some sick value" maybeSelected
+                    , attributes = []
+                    }
+            in
+                [ baseInputTests (queryView <| mockInputModel (Just True))
+                    { label = "To check or not to check?", value = "some sick value", type_ = "checkbox" }
+                , test "is checked" <|
+                    \() ->
+                        queryView (mockInputModel (Just True))
+                            |> Query.find [ Selector.tag "input" ]
+                            |> Query.has [ Selector.boolAttribute "checked" True ]
+                , test "is not checked" <|
+                    \() ->
+                        queryView (mockInputModel (Just False))
+                            |> Query.find [ Selector.tag "input" ]
+                            |> Query.has [ Selector.boolAttribute "checked" False ]
+                , test "is indeterminate" <|
+                    \() ->
+                        queryView (mockInputModel Nothing)
+                            |> Query.find [ Selector.tag "input" ]
+                            |> Query.has [ Selector.boolAttribute "indeterminate" True ]
+                ]
+        ]
+
+
+baseInputTests : Query.Single -> { label : String, value : String, type_ : String } -> Test
+baseInputTests queryView { label, value, type_ } =
+    describe "Basic input tests"
+        [ test "has label with the given label text" <|
+            \() ->
+                queryView
+                    |> Query.find [ Selector.tag "label" ]
+                    |> Query.has [ Selector.text label ]
+        , test "has input with the appropriate value" <|
+            \() ->
+                queryView
+                    |> Query.find [ Selector.tag "input" ]
+                    |> Query.has [ Selector.attribute "value" value ]
+        , test "is an input of the appropriate type" <|
+            \() ->
+                queryView
+                    |> Query.find [ Selector.tag "input" ]
+                    |> Query.has [ Selector.attribute "type" type_ ]
+        ]


### PR DESCRIPTION
Trials alternative input api.

Moves from an InputModel with a what-kind-of-input field on it to a more verbose, more declarative strategy.