### PR TITLE
Improve documentation

### DIFF
--- a/src/Html/A11y.elm
+++ b/src/Html/A11y.elm
@@ -23,7 +23,7 @@ module Html.A11y
 ## Inputs
 
 Inputs defined in this library are offered in three varieties: left-labeled, right-labeled, and featuring an invisible-label.
-Invisible-labelled views require an id.
+Invisible-labeled views require an id.
 
 
 ### Text Inputs

--- a/src/Html/A11y.elm
+++ b/src/Html/A11y.elm
@@ -43,6 +43,47 @@ Invisible-labeled views require an id.
 
 ## Tabs
 
+Together, `tabList`, `tab`, and `tabPanel` describe the pieces of a tab component view.
+
+    import Html exposing (text)
+    import Html.A11y exposing (tab, tabList, tabPanel)
+    import Html.Attributes
+    import Html.Attributes.A11y as A11yAttributes
+
+    view : Html msg
+    view =
+        tabList
+            [ id "tab-list" ]
+            [ tab
+                [ id "tab-1"
+                , A11yAttributes.selected True
+                , A11yAttributes.controls "panel-1"
+                ]
+                [ text "Tab One" ]
+            , tab
+                [ id "tab-2"
+                , A11yAttributes.selected False
+                , A11yAttributes.controls "panel-1"
+                ]
+                [ text "Tab Two" ]
+            , tabPanel
+                [ id "panel-1"
+                , A11yAttributes.labelledBy "tab-1"
+                , A11yAttributes.hidden False
+                , Html.Attributes.hidden False
+                ]
+                [ text "Panel One Content" ]
+            , tabPanel
+                [ id "panel-2"
+                , A11yAttributes.labelledBy "tab-2"
+                , A11yAttributes.hidden True
+                , Html.Attributes.hidden True
+                ]
+                [ text "Panel Two Content" ]
+            ]
+
+For a more fully-fledged example using these helpers check out [elm-tabs](http://package.elm-lang.org/packages/tesk9/elm-tabs/latest).
+
 @docs tabList, tab, tabPanel
 
 

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -150,6 +150,7 @@ For more information on hiding/semi-hiding elements, please see [the a11y projec
 
 Generally, these landmark tags are implicit in HTML5. The default landmark roles
 are specified [here](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html).
+`search` does not have a corresponding HTML5 tag.
 
 @docs banner, complementary, contentInfo, form, main_, navigation, search, application, region
 

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -1115,12 +1115,11 @@ label =
 
 {-| Supported for `grid`, `heading`, `listItem`, `row`, and `tabList`.
 
-This attribute is about hierarchy--how many "levels" deep is an element?
+This attribute is about hierarchy--how many "levels" deep is an element? Please
+refer to the [documentation](https://www.w3.org/TR/wai-aria-1.1/#aria-level) to get a better sense of when to use.
 
     h7 attributes =
         div (heading :: level 7 :: attributes)
-
-Please refer to the [documentation](https://www.w3.org/TR/wai-aria-1.1/#aria-level) to get a better sense of when to use.
 
 -}
 level : Int -> Html.Attribute msg
@@ -1132,13 +1131,13 @@ level =
 
 Indicate whether the `textbox` is for multi-line inputs or single-line inputs.
 
-TODO: should the role just be `textBoxSingleLine` and `textBoxMultiLine` instead?
-
-Careful of Enter behavior on this one.
+Careful of default keyboard behavior when coupling this property with text inputs,
+which by default submit their form group on enter.
 
 -}
 multiLine : Bool -> Html.Attribute msg
 multiLine =
+    --TODO: should the role just be `textBoxSingleLine` and `textBoxMultiLine` instead?
     Widget.multiLine
 
 
@@ -1158,11 +1157,10 @@ multiSelectable =
 
 Careful: default behavior is inconsistent across those roles.
 
-TODO: should the non-default behavior be explicit from the role perspective?
-
 -}
 orientationHorizontal : Html.Attribute msg
 orientationHorizontal =
+    --TODO: should the non-default behavior be explicit from the role perspective?
     Widget.orientationHorizontal
 
 
@@ -1171,11 +1169,10 @@ orientationHorizontal =
 
 Careful: default behavior is inconsistent across those roles.
 
-TODO: should the non-default behavior be explicit from the role perspective?
-
 -}
 orientationVertical : Html.Attribute msg
 orientationVertical =
+    --TODO: should the non-default behavior be explicit from the role perspective?
     Widget.orientationVertical
 
 

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -139,16 +139,19 @@ module Html.Attributes.A11y
 
 ## Hiding content
 
-@docs invisible
-
 For more information on hiding/semi-hiding elements, please see [the a11y project.](http://a11yproject.com/posts/how-to-hide-content/)
+
+@docs invisible
 
 
 ## Landmark
 
-@docs banner, complementary, contentInfo, form, main_, navigation, search, application, region
-
 [On page regions.](https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html)
+
+Generally, these landmark tags are implicit in HTML5. The default landmark roles
+are specified [here](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html).
+
+@docs banner, complementary, contentInfo, form, main_, navigation, search, application, region
 
 
 ## Elements
@@ -434,7 +437,30 @@ banner =
     Landmark.banner
 
 
-{-| "Complements" the main content.
+{-| "Complements" the main content. If there are more than one complementary elements
+on the page, please be sure to use `labeledBy` to point to the heading of each
+complementary element.
+
+The HTML5 `aside` tag has this role by default (you still need to use `labeledBy`
+if there are more than one asides!).
+
+Check out [W3's docs for `complementary`](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/complementary.html)--
+note that you can toggle the "Show Landmarks" button at the top of the page
+to see a real example of using the complementary role!
+
+    import Html.Attributes.A11y exposing (complementary, labeledBy)
+
+    div []
+        [ div
+            [ complementary, labeledBy "extra-thoughts" ]
+            [ h2 [ id "extra-thoughts"] [ text "Extra thoughts..."]
+            , text "some content"
+            ]
+        , div
+            [ complementary, labeledBy "related-docs" ]
+            [ h2 [ id "related-docs"] [ text "Related Documentation"] ]
+        ]
+
 -}
 complementary : Html.Attribute msg
 complementary =

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -485,7 +485,10 @@ contentInfo =
     Landmark.contentinfo
 
 
-{-| A form container.
+{-| A form container. The HTML5 alternative is to use a `form` element with a `name`.
+
+For examples, please see [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/form.html).
+
 -}
 form : Html.Attribute msg
 form =

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -1184,14 +1184,20 @@ orientationVertical =
 
 {-| Supported on `button`.
 
-If you're confused about different button options, please check out these
-[examples](<https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20160317/examples/button/button.html>.
+Use `pressed` when describing a toggle button--a button that can be "toggled" between
+an on state and an off state (or an on state, an indeterminate state, and an off state).
 
-TODO: Move to be a button role option?
+Please check out these [examples](https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20160317/examples/button/button.html)
+as well.
+
+    button
+        [ pressed <| Just True ]
+        [ text "This button should be styled for site viewers such that it's clear it's pressed!" ]
 
 -}
 pressed : Maybe Bool -> Html.Attribute msg
 pressed =
+    --TODO: Move to be a button role option?
     Widget.pressed
 
 

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -506,7 +506,14 @@ main_ =
     Landmark.main_
 
 
-{-| Navigation.
+{-| Navigation--wrap lists of links intended to help your users navigate your site
+in an element with this role or use HTML5's `nav` tag.
+
+If there's more than one `nav` list on a given page, please make sure that the
+navigation is labeled (what kinds of links should your users expect to find in
+this list?). For examples of how to do this using the `labeledBy` property,
+check out [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/navigation.html).
+
 -}
 navigation : Html.Attribute msg
 navigation =

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -1548,13 +1548,12 @@ flowTo =
 Keyboard shortcuts!!! Pass in a list of keyboard shortcuts. See [recommendations](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_shortcuts)
 on how to make good shortcuts.
 
-TODO: Consider adding a keyboard library/type?
-
     keyShortcuts [ "Alt+Shift+P", "Control+F" ]
 
 -}
 keyShortcuts : List String -> Html.Attribute msg
 keyShortcuts =
+    --TODO: Consider adding a keyboard library/type?
     Aria.keyShortcuts
 
 

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -434,7 +434,7 @@ indeterminate =
 generally is implicitly a `banner`. (For specifics on what DOM relationships will
 affect this default behavior, please check out [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/banner.html).)
 
-    import Html exposing (div, h1)
+    import Html exposing (div, h1, text)
     import Html.A11y exposing (img)
     import Html.A11y.Attributes exposing (banner)
     import Html.Attributes exposing (src)
@@ -535,7 +535,25 @@ navigation =
     Landmark.navigation
 
 
-{-| A search input.
+{-| A search input. [W3 docs](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/search.html?)
+
+If you're going to learn about an ARIA Landmark role, this is the one to know,
+as HTML5 does NOT have a corresponding element! Add this property to forms to signify
+that they describe search functionality.
+
+As ever, if there's more than one search element on the page, please be sure to label.
+
+    import Html exposing (button, form, text)
+    import Html.A11y exposing (textLeftLabeled)
+    import Html.Attributes exposing (type_, value)
+    import Html.Attributes.A11y exposing (search)
+
+    form [ search ]
+        [ textLeftLabeled "Search Value" [] <|
+            text "Search for something good"
+        , button [ type_ "submit" ] [ text "Search" ]
+        ]
+
 -}
 search : Html.Attribute msg
 search =

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -317,9 +317,6 @@ See [the spec](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup).
 
 ## Aria
 
-
-## Aria
-
 @docs indeterminate, activeDescendant, controls
 
 

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -495,7 +495,11 @@ form =
     Landmark.form
 
 
-{-| Main content in a document. (There can only be one.)
+{-| Main content in a document. (There should only be one--if you require more than
+one element with role main, make sure each is labeled. See [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/main.html).)
+
+HTML5's `main` tag is implicitly role `main`.
+
 -}
 main_ : Html.Attribute msg
 main_ =

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -148,6 +148,15 @@ For more information on hiding/semi-hiding elements, please see [the a11y projec
 
 [On page regions.](https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html)
 
+Landmarks help your users to navigate your site by giving them "landmarks" to
+the regions they might want to see. Are they trying the `search` the site? Do
+they want to access the `main` content? Do they want information about the content,
+like copyright and legal notices--`contentInfo`, if you will?
+
+Landmarks keep your users from being overwhelmed by a slew of information to sift through
+or from being bored by need to tab through the same old set of unlabeled links on
+every single page of your site.
+
 Generally, these landmark tags are implicit in HTML5. The default landmark roles
 are specified [here](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html).
 `search` does not have a corresponding HTML5 tag.

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -430,7 +430,22 @@ indeterminate =
     Aria.indeterminate
 
 
-{-| This banner should have the page title in it.
+{-| This banner should have the page title in it. In HTML5, the `header` element
+generally is implicitly a `banner`. (For specifics on what DOM relationships will
+affect this default behavior, please check out [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/banner.html).)
+
+    import Html exposing (div, h1)
+    import Html.A11y exposing (img)
+    import Html.A11y.Attributes exposing (banner)
+    import Html.Attributes exposing (src)
+
+
+    div
+        [ banner ]
+        [ h1 [] [ text "Such Site!"]
+        , img "Such Logo!" [ src "logo.png" ]
+        ]
+
 -}
 banner : Html.Attribute msg
 banner =

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -239,7 +239,7 @@ are specified [here](https://www.w3.org/TR/wai-aria-practices/examples/landmarks
 
 ## Widget States and Properties
 
-(Some of these are also globally available:: `busy`, `disabled`, `grabbed`, `hidden`, `invalid`)
+Some of these are also globally available, including: `busy`, `disabled`, `grabbed`, `hidden`, `invalid`
 
 
 ### Page Hierarchy

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -57,6 +57,7 @@ module Html.Attributes.A11y
         , invisible
         , keyShortcuts
         , label
+        , labeledBy
         , labelledBy
         , level
         , link
@@ -311,7 +312,7 @@ See [the spec](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup).
 
 ### Providing More Info
 
-@docs longDescription, details, describedBy, labelledBy, label
+@docs longDescription, details, describedBy, label, labelledBy, labeledBy
 @docs modal, keyShortcuts, roleDescription
 
 
@@ -394,6 +395,15 @@ controls =
 
 
 {-| Creates aria labelledby attribute. Pass the unique string id of the labelling element.
+`labeledBy` and `labelledBy` are identical.
+-}
+labeledBy : String -> Html.Attribute msg
+labeledBy =
+    Aria.labelledBy
+
+
+{-| Creates aria labelledby attribute. Pass the unique string id of the labelling element.
+`labeledBy` and `labelledBy` are identical.
 -}
 labelledBy : String -> Html.Attribute msg
 labelledBy =

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -332,7 +332,7 @@ Learn more about how to use live regions [here](https://www.w3.org/TR/wai-aria-p
 @docs atomic, busy, livePolite, liveAssertive
 
 
-#### Relevant
+### Relevant
 
 @docs relevantAdditions, relevantAdditionsText, relevantAll, relevantRemovals, relevantText
 

--- a/src/Html/Attributes/A11y.elm
+++ b/src/Html/Attributes/A11y.elm
@@ -467,7 +467,18 @@ complementary =
     Landmark.complementary
 
 
-{-| Copyrights, privacy statements, etc.
+{-| Copyrights, privacy statements, etc. There ought only be one element with the
+content info role per page.
+
+You may already have a content info element role fulfilled
+on your page via the HTML5 `footer` element--as long as its context is the `body`, not
+a `section` or `main` or what-have-you (see [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/contentinfo.html) for the full list).
+
+    div [ contentInfo ]
+        [ h2 []
+            [ text "Link to the Privacy Statement You Probably Really Should Read Someday" ]
+        ]
+
 -}
 contentInfo : Html.Attribute msg
 contentInfo =

--- a/tests/Html/Attributes/A11ySpec.elm
+++ b/tests/Html/Attributes/A11ySpec.elm
@@ -235,6 +235,7 @@ ariaTests : Test
 ariaTests =
     describe "Aria"
         [ addsAriaStringAttribute labelledBy ( "labelledby", "label-id" )
+        , addsAriaStringAttribute labeledBy ( "labelledby", "label-id" )
         , addsStringAttribute longDescription ( "longdesc", "element-id" )
         , addsAriaStringAttribute activeDescendant ( "activedescendant", "element-id" )
         , addsAriaBoolAttribute atomic "atomic"


### PR DESCRIPTION
Improves documentation, particularly around:
- consistency of "labell-suffix" versus "label-suffix"
- tabs use case example
- add examples and more detail to the Landmark items
- move todos into the code out of the user-facing docs
- small fixes (e.g., bad markdown link creation)